### PR TITLE
BLAST In-Scanner

### DIFF
--- a/analysis/sl-psychopy-analysis/blast_in_scanner_beh/blast_in_scanner_beh.R
+++ b/analysis/sl-psychopy-analysis/blast_in_scanner_beh/blast_in_scanner_beh.R
@@ -1,7 +1,7 @@
 #  ****************************************************************************
 #  BLAST IN-SCANNER BEHAVIORAL ANALYSIS
 #  Violet Kozloff
-#  Last updated: August 1st, 2019 
+#  Last updated: August 2nd, 2019 
 #  This script extracts data from structured and random blocks across four tasks: auditory (speech and tones) and visual (letters and images).
 #  It measures the mean reaction time and the slope of the reaction time for each participant for each condition.
 #  ****************************************************************************
@@ -314,7 +314,11 @@ for (i in auditory_targets) {
   # Otherwise, if the participant responded during the target
   else if (!is.na(auditory_data[i,] [,"keypress"])
     # and the previous stimulus was not also a target with its own keypress
-    & (!((i-1)%in%auditory_targets) | ((i-1)%in%auditory_targets) & is.na(auditory_data[i-1,] [,"keypress"]))){
+    & (!((i-1)%in%auditory_targets) | ((i-1)%in%auditory_targets) & is.na(auditory_data[i-1,] [,"keypress"]))
+    # 08.02.19
+    # and the previous stimulus was not also a target with no keypress, while the following stimulus was a distractor with a keypress
+    & !(((i-1)%in%auditory_targets & is.na(auditory_data[i-1,] [,"keypress"]) & !(i+1)%in%auditory_targets & !is.na(auditory_data[i+1,] [,"keypress"])))
+  ){
     # Count their response time as the keypress
     auditory_rt <- append(auditory_rt, (auditory_data[i,][,"keypress"]))
     auditory_case4 <- append (auditory_case4, i)

--- a/analysis/sl-psychopy-analysis/blast_in_scanner_beh/blast_in_scanner_beh.R
+++ b/analysis/sl-psychopy-analysis/blast_in_scanner_beh/blast_in_scanner_beh.R
@@ -201,8 +201,7 @@ visual_data$condition <- gsub ("B", "blank", visual_data$condition, ignore.case=
 
 # Explicitly state the task
 visual_data$task <- NA
-visual_data[which(visual_data$stimulus %in% c("1", "2", "3", "4", "5", "6", "7", "8", "9","10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24")),]$task <- "image"
-visual_data[which(visual_data$stimulus %in% c("A", "B", "C", "D", "E", "F", "G", "H", "J", "K", "L", "M")),]$task <- "letter"
+changevisual_data[which(visual_data$stimulus %in% c("A", "B", "C", "D", "E", "F", "G", "H", "J", "K", "L", "M")),]$task <- "letter"
  
 # Standardize all strings into lowercase
 visual_data$stimulus <- tolower(visual_data$stimulus)

--- a/analysis/sl-psychopy-analysis/blast_in_scanner_beh/blast_in_scanner_beh.R
+++ b/analysis/sl-psychopy-analysis/blast_in_scanner_beh/blast_in_scanner_beh.R
@@ -288,6 +288,9 @@ for (i in auditory_targets) {
            # and the preceding stimulus was not also a target
            & ((auditory_data[i-1,][,"tone_target"] != (auditory_data[i-1,][,"stimulus"])))
            & ((auditory_data[i-1,][,"syllable_target"] != (auditory_data[i-1,][,"stimulus"])))
+           #  and two stimuli prior was  also not a target
+           & ((auditory_data[i-2,][,"tone_target"] != (auditory_data[i-2,][,"stimulus"])))
+           & ((auditory_data[i-2,][,"syllable_target"] != (auditory_data[i-2,][,"stimulus"])))
            # and the preceding stimulus came from the same block
            & (auditory_data[i,])$condition==(auditory_data[i-1,]$condition)){
     # Count the response time as how much sooner they responded than when the stimulus was presented (anticipation)
@@ -297,8 +300,8 @@ for (i in auditory_targets) {
   
   # Otherwise, if the participant responded during the target
   else if (!is.na(auditory_data[i,] [,"keypress"])
-    # and the previous stimulus was not also a target
-    & !((i-1)%in%auditory_targets)){
+    # and the previous stimulus was not also a target with its own keypress
+    & (!((i-1)%in%auditory_targets) | ((i-1)%in%auditory_targets) & is.na(auditory_data[i-1,] [,"keypress"]))){
     # Count their response time as the keypress
     auditory_rt <- append(auditory_rt, (auditory_data[i,][,"keypress"]))
     #auditory_case4 <- append (auditory_case4, i)
@@ -508,6 +511,9 @@ for (i in visual_targets) {
            # and the preceding stimulus was not also a target
            & ((visual_data[i-1,][,"image_target"] != (visual_data[i-1,][,"stimulus"])))
            & ((visual_data[i-1,][,"letter_target"] != (visual_data[i-1,][,"stimulus"])))
+           #  and two stimuli prior was  also not a target
+           & ((visual_data[i-2,][,"image_target"] != (visual_data[i-2,][,"stimulus"])))
+           & ((visual_data[i-2,][,"letter_target"] != (visual_data[i-2,][,"stimulus"])))
            # and the preceding stimulus came from the same block
            & (visual_data[i,])$condition==(visual_data[i-1,]$condition)){
     # Count the response time as how much sooner they responded than when the stimulus was presented (anticipation)
@@ -517,8 +523,8 @@ for (i in visual_targets) {
   
   # Otherwise, if the participant responded during the target
   else if (!is.na(visual_data[i,] [,"keypress"])
-           # and the previous stimulus was not also a target
-           & !((i-1)%in%visual_targets)){
+           # and the previous stimulus was not also a target with its own keypress
+           & (!((i-1)%in%visual_targets) | ((i-1)%in%visual_targets) & is.na(visual_data[i-1,] [,"keypress"]))){
     # Count their response time as the keypress
     visual_rt <- append(visual_rt, (visual_data[i,][,"keypress"]))
     #visual_case4 <- append (visual_case4, i)
@@ -661,7 +667,7 @@ for(id in (unique(visual_part_id))){
 
 visual_rt_slopes <- cbind(unique(visual_part_id), random_lsl_rt_slope, random_vsl_rt_slope, structured_lsl_rt_slope, structured_vsl_rt_slope)
 colnames(visual_rt_check)[1] <- "visual_part_id"
-colnames(exp_visual_mean_rts) <- c("visual_part_id", "random_letter_mean_rt", "random_image_mean_rt", "structured_letter_mean_rt", "structured_image_mean_rt")
+colnames(exp_visual_mean_rts) <- c("visual_part_id", "random_letter_rt_slope", "random_image_rt_slope", "structured_letter_rt_slope", "structured_image_rt_slope")
 colnames(visual_rt_slopes)[1] <- "visual_part_id"
 visual_output <- merge(merge(visual_rt_check, exp_visual_mean_rts), visual_rt_slopes)
 

--- a/analysis/sl-psychopy-analysis/blast_in_scanner_beh/blast_in_scanner_beh.R
+++ b/analysis/sl-psychopy-analysis/blast_in_scanner_beh/blast_in_scanner_beh.R
@@ -12,19 +12,21 @@
 # Prepare files ------------------------------------------------------------
 
 # Load packages
-install.packages("plyr")
-install.packages("reshape")
+#install.packages("plyr")
+#install.packages("reshape")
+
 library ("plyr")
 library("reshape")
 
 # Set working directory (note: specific to MAC)
-setwd("/Volumes/data/projects/blast/data/mri/in_scanner_behavioral/raw_data/adult/sl_raw_data")
+#setwd("/Volumes/data/projects/blast/data/mri/in_scanner_behavioral/raw_data/adult/sl_raw_data")
 # Alternate working directory if the above throws error (depends on how NAS is mounted)
 # setwd("/Volumes/data-1/projects/blast/data/mri/in_scanner_behavioral/raw_data/adult/sl_raw_data")
 # Child working directory
 # setwd("/Volumes/data/projects/blast/data/mri/in_scanner_behavioral/raw_data/child/sl_raw_data")
 # Alternate working directory if the above throws error (depends on how NAS is mounted)
 # setwd("/Volumes/data-1/projects/blast/data/mri/in_scanner_behavioral/raw_data/child/sl_raw_data")
+setwd("/Volumes/data/users/diana/in_scanner_behavioral/adult/sl_raw_data")
 
 # Remove objects in environment
 rm(list=ls())
@@ -285,8 +287,8 @@ for (i in auditory_targets) {
     auditory_case2 <- append (auditory_case2, i)
   }  
   
-  # Otherwise, if the participant responded during the stimulus preceding the target
-  else if (!is.na(auditory_data[i-1,] [,"keypress"])  
+  # 08.06.19 Otherwise, if the participant responded during the stimulus preceding the target, which was in the same block
+  else if (!is.na(auditory_data[i-1,] [,"keypress"]) & auditory_data[i-1,] [,"condition"]==auditory_data[1,] [,"condition"]
            # and the preceding stimulus was not also a target
            & ((auditory_data[i-1,][,"tone_target"] != (auditory_data[i-1,][,"stimulus"])))
            & ((auditory_data[i-1,][,"syllable_target"] != (auditory_data[i-1,][,"stimulus"])))
@@ -298,13 +300,16 @@ for (i in auditory_targets) {
            & (auditory_data[i,])$condition==(auditory_data[i-1,]$condition)
            # and, if in a random block
            & (auditory_data[i,]$condition=="structured" 
-              # EITHER the following stimulus is not a target from the same block,
-              | (!(i+1) %in% auditory_targets & auditory_data[i+1,]$condition!=auditory_data[i,]$condition
+              # 08.06.19
+              # EITHER they did not press in the following trial
+              | !((i+1) %in% auditory_targets & auditory_data[i+1,]$condition==auditory_data[i,]$condition)
+              # OR the following stimulus is not a target from the same block,
+              | !((i+1) %in% auditory_targets & auditory_data[i+1,]$condition==auditory_data[i,]$condition)
               # OR it is a target from the same block, but has neither an on-target keypress 
               | ((i+1) %in% auditory_targets & auditory_data[i+1,]$condition==auditory_data[i,]$condition & is.na(auditory_data[i+1,]$keypress)
                 # nor a delay from the same block
                 & (auditory_data[i+2,]$condition!=auditory_data[i,]$condition | is.na(auditory_data[i+2,]$keypress))
-  )))){
+  ))){
     # Count the response time as how much sooner they responded than when the stimulus was presented (anticipation)
     auditory_rt <- append(auditory_rt, (auditory_data[i-1,][,"keypress"]-480))
     auditory_case3 <- append (auditory_case3, i)
@@ -709,10 +714,11 @@ for(id in (unique(visual_part_id))){
 
 visual_rt_slopes <- cbind(unique(visual_part_id), random_lsl_rt_slope, random_vsl_rt_slope, structured_lsl_rt_slope, structured_vsl_rt_slope)
 colnames(visual_rt_check)[1] <- "visual_part_id"
-colnames(exp_visual_mean_rts) <- c("visual_part_id", "random_letter_rt_slope", "random_image_rt_slope", "structured_letter_rt_slope", "structured_image_rt_slope")
+colnames(exp_visual_mean_rts) <- c("visual_part_id", "random_image_mean_rt", "random_letter_mean_rt", "structured_image_mean_rt", "structured_letter_mean_rt")
 colnames(visual_rt_slopes)[1] <- "visual_part_id"
 visual_output <- merge(merge(visual_rt_check, exp_visual_mean_rts), visual_rt_slopes)
 
 # Write  results and save them to NAS
 write.csv(auditory_output, paste0(output_path, "adult_in_scanner_auditory_behavioral.csv"))
 write.csv(visual_output, paste0(output_path, "adult_in_scanner_visual_behavioral.csv"))
+


### PR DESCRIPTION
Accounts for ambiguous keypresses in random blocks.

The following cases yield these outcomes:

Trial 1: target + keypress
Trial 2: target + keypress
Outcome: Hits on trials 1 and 2

Trial 1: Target
Trial 2: Keypress
Trial 3: Target
Trial 4: Keypress
Outcome: Delays on trials 1 and 3

Trial 1: Target
Trial 2: Target + keypress
Outcome: Target on trial 2

Trial 1: Target
Trial 2: Distractor + keypress
Trial 3: Target
Outcome: Delay on trial 1

Trial 1: Target
Trial 2: Target + keypress
Trial 3: Distractor + keypress 
Outcome: Delays on trials 1 and 2

Trial 1: Target
Trial 2: Distractor + keypress
Trial 3: Target
Trial 4: Distractor + keypress
Outcome: Delays on trial 1 and 3

Trial 1: Distractor + keypress
Trial 2: Target + keypress
Trial 3: Target + keypress
Outcome: Hits on trials 2 and 3

Trial 1: Distractor + keypress
Trial 2: Target 
Outcome: Anticipation on trial 2

Trial 1: Distractor + keypress
Trial 2: Target + keypress
Outcome: Hit on trial 2

Trial 1: Distractor + keypress
Trial 2: Target + keypress
Trial 3: Distractor + keypress
Outcome: For random blocks, on-target on trial 2. For structured blocks, anticipation on trial 2.

Trial 1: Distractor + keypress
Trial 2: Target
Trial 3: Distractor + keypress
Outcome: For random blocks, delay on trial 2. For structured blocks, anticipation on trial 2.